### PR TITLE
Set timeout to getPreSignedUrls and getPreSignedTAUrls function

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ This prototype project is intended to show a way to implement multipart upload a
 cdk deploy --context env="randnumber" --context whitelistip="xx.xx.xxx.xxx"
 ```
 An additional context variable called "urlExpiry" can be used to set specific expiration time on the S3 presigned URL. The default value is set at 300 seconds (5 min). A new S3 bucket with the name "document-upload-bucket-randnumber" is created for storing the uploaded files, and the whitelistip value is used to allow API Gateway access from this IP address only. 
+
+An additional context variable called "functionTimeout" can be used to set specific timeout for the AWS Lambda function responsible for generating presigned URLs. With a higher number of parts, timeouts may occur, but it can be extended as needed.
+
 - Make note of the API Gateway endpoint URL.
 
 ### Frontend 

--- a/backendV2/lib/multipart_s3_upload-stack.ts
+++ b/backendV2/lib/multipart_s3_upload-stack.ts
@@ -12,6 +12,7 @@ export class MultipartS3UploadStack extends cdk.Stack {
     super(scope, id, props);
     const env = cdk.Stack.of(this).node.tryGetContext('env');
     const expires = cdk.Stack.of(this).node.tryGetContext('urlExpiry') ?? '300';
+    const timeout = Number(cdk.Stack.of(this).node.tryGetContext('functionTimeout') ?? '3');
 
     const s3Bucket = new s3.Bucket(this, "document-upload-bucket", {
       bucketName: `document-client-upload-${env}`,
@@ -98,7 +99,8 @@ export class MultipartS3UploadStack extends cdk.Stack {
         BUCKET_NAME: s3Bucket.bucketName,
         URL_EXPIRES: expires
       },
-      functionName: `multipart-upload-getPreSignedUrls-${env}`
+      functionName: `multipart-upload-getPreSignedUrls-${env}`,
+      timeout: cdk.Duration.seconds(timeout)
     });
     const getPreSignedTAUrlsLambda = new NodejsFunction(this, 'getPreSignedTAUrlsHandler', {
       ...commonNodeJsProps,
@@ -107,7 +109,8 @@ export class MultipartS3UploadStack extends cdk.Stack {
         BUCKET_NAME: s3Bucket.bucketName,
         URL_EXPIRES: expires
       },
-      functionName: `multipart-upload-getPreSignedTAUrls-${env}`
+      functionName: `multipart-upload-getPreSignedTAUrls-${env}`,
+      timeout: cdk.Duration.seconds(timeout)
     });
     const finalizeLambda = new NodejsFunction(this, 'finalizeHandler', {
       ...commonNodeJsProps,


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Thank you for providing an awesome solution :)

After deploying this solution to the `ap-northeast-1` (Tokyo region) and testing, I encountered a timeout issue with the Lambda function `getPreSignedUrls` and `getPreSignedTAUrls` when using a higher number of parts ~~Transfer Acceleration~~. Currently, the Lambda function's timeout is unset, default is 3 seconds.

```
2024-01-03T01:28:31.023Z c8f1b69c-9823-4418-ab9a-cf48a0bc55bb Task timed out after 3.15 seconds
2024-01-03T01:31:28.984Z 928bde21-3a8f-4f5c-888b-6d781ff8a831 Task timed out after 3.12 seconds
2024-01-03T01:46:44.240Z 18e402db-214b-42d8-93fa-75b09bca0a0e Task timed out after 3.03 seconds
2024-01-03T01:49:57.167Z e0cf6504-075a-4ed0-b83b-cf302b2e97b3 Task timed out after 3.16 seconds
2024-01-03T01:57:05.761Z e4f2922d-aca6-40df-87ec-9f07798cc9c9 Task timed out after 3.05 seconds
```

I've enabled specifying the timeout value through a context variable ~~I've updated it to 10 seconds~~, and it seems to work fine in my environment.

Could you review please? Thanks.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.